### PR TITLE
fix a bug: detected bbox connecting with multiple GT bbox

### DIFF
--- a/src/DetectionEvaluator.hpp
+++ b/src/DetectionEvaluator.hpp
@@ -126,8 +126,7 @@ namespace smns {
                     const size_t intersect_size = GT.self.intersect(sbj.self).size();
 
                     if (intersect_size < evaluated) {
-                        accepted = &GT;
-                        evaluated = intersect_size;
+                        dropped.push_back(GT);
                     }
                     else {
                         if (accepted)


### PR DESCRIPTION
After GTs are accepted, 1 detected bbox should only be connected with 1 GT bbox or none.